### PR TITLE
AGTC-76 README links changed to reflect our new docs deployment after repository rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 
 # Project Name
 [![Report Issue on Jira](https://img.shields.io/badge/Report%20Issues-Jira-0052CC?style=flat&logo=jira-software)](https://temple-cis-projects-in-cs.atlassian.net/jira/software/c/projects/AGTC/issues)
-[![Deploy Docs](https://github.com/Capstone-Projects-2025-Spring/project-the-aac-team-sec-2/actions/workflows/deploy.yml/badge.svg)](https://github.com/Capstone-Projects-2025-Spring/project-the-aac-team-sec-2/actions/workflows/deploy.yml)
-[![Documentation Website Link](https://img.shields.io/badge/-Documentation%20Website-brightgreen)](https://capstone-projects-2025-spring.github.io/project-the-aac-team-sec-2/)
+[![Deploy Docs](https://github.com/Capstone-Projects-2025-Spring/aac-go-fish/actions/workflows/deploy.yml/badge.svg)](https://github.com/Capstone-Projects-2025-Spring/aac-go-fish/actions/workflows/deploy.yml)
+[![Documentation Website Link](https://img.shields.io/badge/-Documentation%20Website-brightgreen)](https://capstone-projects-2025-spring.github.io/aac-go-fish/)
 
 
 </div>


### PR DESCRIPTION
The links in the README were outdated and pointing to what would be our old repo name's deployments. I changed the README to reflect the repository being renamed.