### PR TITLE
[AGTC-154] Send order components to manager

### DIFF
--- a/backend/game.py
+++ b/backend/game.py
@@ -6,7 +6,7 @@ import threading
 import structlog
 
 from .game_state import Lobby, Player
-from .models import Burger, Chat, Drink, Fry, GameEnd, GameStart, Message, NewOrder, Order, Role
+from .models import Burger, Chat, Drink, Fry, GameEnd, GameStart, Message, NewOrder, Order, OrderComponent, Role
 
 logger = structlog.stdlib.get_logger(__file__)
 
@@ -39,6 +39,8 @@ class GameLoop:
                         return
                     case Chat() as c:
                         self.typing_indicator(c)
+                    case OrderComponent() as component:
+                        self.manager.send(Message(data=component))
                     case _:
                         logger.warning("Unimplemented message.", message=message.data)
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -48,6 +48,7 @@ class GameStateUpdateKind(StrEnum):
     role_assignment = "role_assignment"
     order_score = "order_score"
     order_submission = "order_submission"
+    order_component = "order_component"
     day_end = "day_end"
 
 
@@ -77,6 +78,15 @@ class OrderScore(BaseModel):
     game_state_update_type: Literal[GameStateUpdateKind.order_score] = GameStateUpdateKind.order_score
 
     score: float
+
+
+class OrderComponent(BaseModel):
+    """A finished component is submitted to the manager."""
+
+    type: Literal[MessageKind.game_state] = MessageKind.game_state
+    game_state_update_type: Literal[GameStateUpdateKind.order_component] = GameStateUpdateKind.order_component
+
+    component: Burger | Fry | Drink
 
 
 class OrderSubmission(BaseModel):
@@ -123,7 +133,8 @@ class DayEnd(BaseModel):
 
 
 type GameStateUpdate = Annotated[
-    NewOrder | RoleAssignment | OrderScore | OrderSubmission | DayEnd, Field(discriminator="game_state_update_type")
+    NewOrder | RoleAssignment | OrderScore | OrderSubmission | OrderComponent | DayEnd,
+    Field(discriminator="game_state_update_type"),
 ]
 
 

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -12,6 +12,7 @@ from backend.models import (
     Message,
     NewOrder,
     Order,
+    OrderComponent,
     OrderScore,
     OrderSubmission,
     PlayerJoin,
@@ -70,6 +71,18 @@ from backend.models import (
             '{"data": {"type": "game_state", "game_state_update_type": "order_score", "score": 1}}',
             Message(data=OrderScore(score=1)),
             id="OrderScore",
+        ),
+        pytest.param(
+            """\
+            {
+                "data": {
+                    "type": "game_state",
+                    "game_state_update_type": "order_component",
+                    "component": {"ingredients": ["bread", "bread"]}
+                }
+            }""",
+            Message(data=OrderComponent(component=Burger(ingredients=["bread", "bread"]))),
+            id="OrderComponent",
         ),
         pytest.param(
             """\


### PR DESCRIPTION
Originally the ticket called for an extra field on the `OrderSubmission` model in order to distinguish between complete and partial orders, but I instead added a new model because I think this is simpler.