### PR TITLE
NGINX changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,11 @@
 ### Dev
 `docker compose -f compose.yaml -f compose.dev.yaml up --build`
 
+I am currently testing with - andriy
+`docker compose -f compose.dev.yaml up --build`
+
 This will run the frontend and backend. The frontend is accessible at
-`localhost:8000` and the backend is accessible at `localhost:8000/api`.
+`localhost:3000` and the backend is accessible at `localhost:8000`.
 
 ## Backend
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -24,4 +24,4 @@ ENV PATH="/app/.venv/bin:$PATH"
 
 WORKDIR /app
 
-CMD ["fastapi", "run", "./hello.py"]
+CMD ["fastapi", "run", "./hello.py", "--root-path", "/api"]

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -9,20 +9,37 @@ services:
     environment:
       ENV: demo
       LOG_LEVEL: DEBUG
-      FRONTEND_URL: localhost:8000
+      FRONTEND_URL: localhost:3000
+    ports:
+      - "8000:8000"
 
   frontend:
     build:
       context: ./frontend
       dockerfile: Dockerfile
-      target: prod
       additional_contexts:
         metadata: .
     ports:
-      - "127.0.0.1:8000:80"
+      - "3000:3000"
     volumes:
       - ./frontend:/app
       - ./node_modules:/app/node_modules
     tty: true
     depends_on:
+      - backend
+
+  nginx:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+      additional_contexts:
+        metadata: .
+    volumes:
+      - ./frontend/build:/usr/share/nginx/html
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf
+    tty: true
+    ports:
+      - "80:80"
+    depends_on:
+      - frontend
       - backend

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,10 +1,9 @@
 server {
     listen 80;
-    server_name your-ec2-public-ip;
+    server_name localhost;
 
     location / {
         root /usr/share/nginx/html;
-        index index.html;
         try_files $uri /index.html;
     }
 


### PR DESCRIPTION
I could only get it to either map 80 -> internal 3000 to show the frontend.
or have nginx on 80 and map /api/ to internal 8000. 

When the nginx is ran in the frontend container it can serve the build files, but I could not get it to route /api/ to 8000.
When the nginx is ran in its own container it can route /api/ to 8000 but could not serve the frontend properly.