### PR TITLE
swagger docs cleanup

### DIFF
--- a/documentation/static/openapi.yaml
+++ b/documentation/static/openapi.yaml
@@ -17,47 +17,43 @@ paths:
                 type: object
                 properties:
                   code:
-                    type: string
-                    example: Fish-Turtle-Shark
-  /lobby/{code}:
+                    type: array
+                    example:
+                      - Patty
+                      - Cheese
+                      - Tomato
+  /lobby/join:
     post:
       summary: Join Lobby
-      description: Joins a player to a lobby by its unique game code, returning new player information and player avatars.
+      description: Joins a player to a lobby by its unique game code, returning new player information.
       operationId: lobby_code_post
-      parameters:
-      - name: code
-        in: path
-        required: true
-        schema:
-          type: string
-          title: Code
-          description: Lobby Code
+      requestBody:
+        description: Lobby Code
+        content:
+          application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: array
+                    example:
+                      - Patty
+                      - Cheese
+                      - Tomato
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  self:
-                    type: object
-                    properties:
-                      avatar:
-                        type: string
-                        example: Fish
-                      uuid:
-                        type: string
-                        example: 3e6b52bf-23ae-4f50-ba84-ad35ed1df31b
-                  players:
-                    type: array
-                    example:
-                      - Shark
-                      - Turtle
-                      - Fish
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      example: 3e6b52bf-23ae-4f50-ba84-ad35ed1df31b
         '404':
           description: Lobby Not Found
   /ws/:
     get:
       summary: Websocket Connection
-      description: Handles a WebSocket connection for receiving and responding to messages.
+      description: Handles a WebSocket connection for receiving and responding to messages. For more information see Websocket schema.


### PR DESCRIPTION
Originally I was going to change methods in the API to reflect swagger docs but the API has been cleaned up much more since I last looked at it so this ended up being the opposite: Updating swagger docs to reflect our simpler API