### PR TITLE
AGTC-257 allow configuring role switching mechanic

### DIFF
--- a/HOSTING.md
+++ b/HOSTING.md
@@ -73,12 +73,14 @@ git clone https://github.com/Capstone-Projects-2025-Spring/aac-go-fish.git
 ```
 FRONTEND_URL: "https://bankruptcyassociation.com"
 ```
-2. (optional) Select backend MODE field in `compose.yaml` to set game mode
-- cycle: randomizes user roles and shuffles after each day (default if left blank)
-- fixed: each user stays on same role for every day, assigned by join order (Manager -> Burger -> Drink -> Side)
-'''
-MODE: "fixed"
-'''
+2. _(optional)_ Select backend MODE field in `compose.yaml` to set game mode
+
+   Options:
+   - **cycle**: randomizes user roles and shuffles after each day **(default if left blank)**
+   - **fixed**: each user stays on same role for every day, assigned by join order (Manager -> Burger -> Drink -> Side)
+```
+MODE: "cycle"
+```
 3. Change `nginx.conf` to use your Elastic IP and domain name
 ```
     server_name bankruptcyassociation.com www.bankruptcyassociation.com 54.159.150.176;

--- a/HOSTING.md
+++ b/HOSTING.md
@@ -69,11 +69,17 @@ git clone https://github.com/Capstone-Projects-2025-Spring/aac-go-fish.git
 ---
 
 ## 7. Configure Environment Variables
-1. Change FRONTEND_URL field in compose.yaml to your domain name
+1. Change backend FRONTEND_URL field in `compose.yaml` to your domain name
 ```
 FRONTEND_URL: "https://bankruptcyassociation.com"
 ```
-2. Change nginx.conf to use your Elastic IP and domain name
+2. (optional) Select backend MODE field in `compose.yaml` to set game mode
+- cycle: randomizes user roles and shuffles after each day (default if left blank)
+- fixed: each user stays on same role for every day, assigned by join order (Manager -> Burger -> Drink -> Side)
+'''
+MODE: "fixed"
+'''
+3. Change `nginx.conf` to use your Elastic IP and domain name
 ```
     server_name bankruptcyassociation.com www.bankruptcyassociation.com 54.159.150.176;
 ```

--- a/backend/constants.py
+++ b/backend/constants.py
@@ -5,6 +5,7 @@ class Settings(BaseSettings):
     """App settings."""
 
     env: str = "demo"
+    mode: str = "cycle"
     frontend_url: str = "http://localhost"
     log_level: str = "DEBUG"
     json_logs: bool = False

--- a/compose-example.yaml
+++ b/compose-example.yaml
@@ -8,6 +8,7 @@ services:
     command: ["fastapi", "run", "./hello.py", "--root-path", "/api"]
     environment:
       ENV: prod
+      MODE: cycle
       LOG_LEVEL: WARNING
       JSON_LOGS: true
       FRONTEND_URL: "https://bankruptcyassociation.com"

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -10,6 +10,7 @@ services:
         metadata: .
     environment:
       ENV: demo
+      MODE: cycle
       LOG_LEVEL: DEBUG
       FRONTEND_URL: localhost:3000
       JSON_LOGS: true


### PR DESCRIPTION
**WIP: Known issue where the frontend tutorial is shown even when roles don't swap/user has seen tutorial before.** Not sure if we'll keep as is, I'm waiting on Addison's frontend refactors if I'll fix this

In this pr:
- Backend changes: new environment variable **MODE** to control the role switching mechanics
   - **cycle**: randomizes user roles and shuffles after each day **(default if left blank)**
   - **fixed**: each user stays on same role for every day, assigned by join order (Manager -> Burger -> Drink -> Side)
- Documentation changes: this information is given in `HOSTING.md` so whoever is deploying our project is aware of the multiple game modes

**Default mode is still cycle,** to test fixed mode, change the backend `MODE` environment variable in `compose.dev.yaml` to fixed instead of cycle